### PR TITLE
Removes always failing check

### DIFF
--- a/tga.js
+++ b/tga.js
@@ -83,7 +83,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 
 		// Indexed type
 		if (header.hasColorMap) {
-			if (header.colorMapLength > 256 || header.colorMapSize !== 24 || header.colorMapType !== 1) {
+			if (header.colorMapLength > 256 || header.colorMapType !== 1) {
 				throw new Error('Targa::checkHeader() - Invalid colormap for indexed type');
 			}
 		}


### PR DESCRIPTION
heade.colorMapSize variable doesn't exist, is always undefined, thus colormap files always fails.